### PR TITLE
Fix menu entry visibility

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,6 +3,8 @@ Le format du fichier est basé sur [Tenez un ChangeLog](http://keepachangelog.co
 
 ## [Non Distribué]
 
+## [4.0.55] - 03-02-2022
+- correction de l'affichage de AdvanceDictionary dans le menu setup
 ## [4.0.54] - 19-12-2022
 - Compatibilité newToken() des versions recentes de dolibarr
 

--- a/core/modules/modAdvanceDictionaries.class.php
+++ b/core/modules/modAdvanceDictionaries.class.php
@@ -72,7 +72,7 @@ class modAdvanceDictionaries extends DolibarrModules
 		$this->editor_url = 'http://www.open-dsi.fr';
 
 		// Possible values for version are: 'development', 'experimental', 'dolibarr', 'dolibarr_deprecated' or a version string like 'x.y.z'
-		$this->version = '4.0.54';
+		$this->version = '4.0.55';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Name of image file used for this module.

--- a/core/modules/modAdvanceDictionaries.class.php
+++ b/core/modules/modAdvanceDictionaries.class.php
@@ -245,7 +245,7 @@ class modAdvanceDictionaries extends DolibarrModules
             'url' => '/advancedictionaries/admin/dictionaries.php',
             'langs' => 'advancedictionaries@advancedictionaries', // Lang file to use (without .lang) by module. File must be in langs/code_CODE/ directory.
             'position' => 100,
-            'enabled' => '($conf->advancedictionaries->enabled && $leftmenu == \'setup\')',// Define condition to show or hide menu entry. Use '$conf->monmodule->enabled' if entry must be visible if module is enabled.
+            'enabled' => '$conf->advancedictionaries->enabled',// Define condition to show or hide menu entry. Use '$conf->monmodule->enabled' if entry must be visible if module is enabled.
             'perms' => '$user->rights->advancedictionaries->read', // Use 'perms'=>'$user->rights->monmodule->level1->level2' if you want your menu with a permission rules
             'target' => '',
             'user' => 0


### PR DESCRIPTION
Fix: menu entry for advancedictionary was not always visible on Oblyon due to parameter leftmenu=setup not being set.